### PR TITLE
Bugfix - Fix getBindingsForExchangeAndQueue link

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,7 +122,7 @@ AmqpStats.prototype.getBindingsForVHost = function getBindingsForVHost (vhost, c
 };
 
 AmqpStats.prototype.getBindingsForExchangeAndQueue = function getBindingsForExchangeAndQueue (vhost, exchange, queue, callback) {
-  this.sendRequest('GET', 'queues/' + encodeURIComponent(vhost) + '/e/' + encodeURIComponent(exchange) + '/q/' + encodeURIComponent(queue) + '/', {}, callback);
+  this.sendRequest('GET', 'bindings/' + encodeURIComponent(vhost) + '/e/' + encodeURIComponent(exchange) + '/q/' + encodeURIComponent(queue) + '/', {}, callback);
 };
 
 // Virtual Hosts


### PR DESCRIPTION
The getBindingsForExchangeAndQueue should have "bindings" as the base
URL, not "queues".

See http://hg.rabbitmq.com/rabbitmq-management/raw-file/rabbitmq_v3_3_4/priv/www/api/index.html
Entry "/api/bindings/vhost/e/exchange/q/queue"