### PR TITLE
fix engine version for yarn

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "main": "index.js",
   "engines": {
-    "node": "~0.6.0"
+    "node": ">=0.6.0"
   },
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
I got this error when I install the package with yarn:
```
error amqp-stats@0.0.14: The engine "node" is incompatible with this module. Expected version "~0.6.0".
error Found incompatible module
```