### PR TITLE
Parameter fixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -202,17 +202,17 @@ AmqpStats.prototype.sendRequest = function sendRequest (method, path, params, ca
     } else if (data === "Not found.") {
       callback(new Error("Undefined."));
     } else {
-      data = null;
+      var out = null;
       try {
-        data = JSON.parse(data);
+        out = JSON.parse(data);
       } catch(e) { 
         // do nothing
       } finally {
-        if ( !data ) {
-          data = {};
+        if ( !out ) {
+          out = {};
         }
       }
-      callback(null, res, data);
+      callback(null, res, out);
     }
   });
 }

--- a/index.js
+++ b/index.js
@@ -185,7 +185,7 @@ AmqpStats.prototype.sendRequest = function sendRequest (method, path, params, ca
   }
 
   if ( method.toUpperCase() == 'GET' ) {
-    opts.url += qs.stringify(params)
+    opts.url += '?' + qs.stringify(params)
   } else {
     opts.form = true
     opts.body = qs.stringify(params)
@@ -197,7 +197,7 @@ AmqpStats.prototype.sendRequest = function sendRequest (method, path, params, ca
     //console.log('data: ', data);
     if (err) { 
       callback(err);
-    } else if (res.statusCode > 200) {
+    } else if (res.statusCode > 201) {
       callback(new Error("Status code: "+ res.statusCode));
     } else if (data === "Not found.") {
       callback(new Error("Undefined."));

--- a/index.js
+++ b/index.js
@@ -198,7 +198,7 @@ AmqpStats.prototype.sendRequest = function sendRequest (method, path, params, ca
 
       callback(err);
 
-    } else if (res.statusCode >= 300) {
+    } else if (res.statusCode >= 400) {
 
       let e = new Error(res.statusMessage);
       e.status = res.statusCode;

--- a/index.js
+++ b/index.js
@@ -178,12 +178,20 @@ AmqpStats.prototype.alive = function alivenessTest (vhost, callback) {
 // Utility used by all other calls. Can also be used seperately to make any API call not specified above.
 
 AmqpStats.prototype.sendRequest = function sendRequest (method, path, params, callback) {
-  request({
+
+  var opts = {
     method: method,
-    url: this.protocol + "://" + this.username + ":" + this.password + "@" + this.hostname + "/api/" + path + qs.stringify(params),
-    body: qs.stringify(params),
-    form: true
-  }, function(err, res, data){
+    url: this.protocol + "://" + this.username + ":" + this.password + "@" + this.hostname + "/api/" + path
+  }
+
+  if ( method.toUpperCase() == 'GET' ) {
+    opts.url += qs.stringify(params)
+  } else {
+    opts.form = true
+    opts.body = qs.stringify(params)
+  }
+
+  request(opts, function(err, res, data){
     //console.log(err);
     //console.log(res.statusCode);
     //console.log('data: ', data);

--- a/index.js
+++ b/index.js
@@ -185,33 +185,43 @@ AmqpStats.prototype.sendRequest = function sendRequest (method, path, params, ca
   }
 
   if ( method.toUpperCase() == 'GET' ) {
-    opts.url += '?' + qs.stringify(params)
+    opts.url += '?' + qs.stringify(params);
   } else {
-    opts.form = true
-    opts.body = qs.stringify(params)
+    opts.json = params;
   }
 
   request(opts, function(err, res, data){
     //console.log(err);
     //console.log(res.statusCode);
     //console.log('data: ', data);
-    if (err) { 
+    if (err) {
+
       callback(err);
-    } else if (res.statusCode > 201) {
-      callback(new Error("Status code: "+ res.statusCode));
+
+    } else if (res.statusCode >= 300) {
+
+      let e = new Error(res.statusMessage);
+      e.status = res.statusCode;
+
+      callback(e);
+
     } else if (data === "Not found.") {
+
       callback(new Error("Undefined."));
+
     } else {
+
       var out = null;
       try {
         out = JSON.parse(data);
-      } catch(e) { 
+      } catch(e) {
         // do nothing
       } finally {
         if ( !out ) {
           out = {};
         }
       }
+
       callback(null, res, out);
     }
   });

--- a/index.js
+++ b/index.js
@@ -202,7 +202,16 @@ AmqpStats.prototype.sendRequest = function sendRequest (method, path, params, ca
     } else if (data === "Not found.") {
       callback(new Error("Undefined."));
     } else {
-      data = JSON.parse(data);
+      data = null;
+      try {
+        data = JSON.parse(data);
+      } catch(e) { 
+        // do nothing
+      } finally {
+        if ( !data ) {
+          data = {};
+        }
+      }
       callback(null, res, data);
     }
   });


### PR DESCRIPTION
- When trying to use `sendRequest` method directly for creating queues (PUT), i noticed that the query param string was being embedded within the queue name itself.

- Arguments like `{ durable:true }` or `{ 'x-message-ttl': 10000 }` weren't making it over.

- RabbitMQ might return status codes above 200 (e.g. 201 on successful create), so I increased the error status code check >= 400

- When manually building an `Error` object, I include the actual status message returned by the request module